### PR TITLE
React Native 0.14+ support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var NativeModules = require('NativeModules');
+var NativeModules = require('react-native').NativeModules;
 var RNEnvironmentManagerIOS = NativeModules.RNEnvironmentManagerIOS;
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-env",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Environment manager for react native",
   "main": "index.js",
   "author": "@joeferraro",


### PR DESCRIPTION
Uses `require('react-native').NativeModules` rather than `require('NativeModules')`
